### PR TITLE
Enable GraphQL endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,6 @@ ARG WS_VERSION=1.0-SNAPSHOT
 ENV JETTY_WEBAPPS_DIR /var/lib/jetty/webapps
 
 COPY ./target/jersey-ws-template-$WS_VERSION.war $JETTY_WEBAPPS_DIR/ROOT.war
+
+RUN java -jar "$JETTY_HOME/start.jar" --add-module=annotations,server,http,deploy,servlet,webapp,resources,jsp
+RUN rm -rf /var/lib/jetty/start.d/websocket.ini

--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,16 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 
+        <version.elide>7.0.0-pr6</version.elide>
+        <version.validation.api>3.0.1</version.validation.api>
+        <version.jersey>3.1.1</version.jersey>
+        <hibernate.version>6.2.4.Final</hibernate.version>
         <version.jcip.annotations>1.0</version.jcip.annotations>
         <version.slf4j>2.0.7</version.slf4j>
         <version.logback>1.4.7</version.logback>
         <version.owner>1.0.12</version.owner>
         <version.groovy>4.0.6</version.groovy>
+        <version.jetty>11.0.15</version.jetty>
 
         <version.maven.war.plugin>3.2.2</version.maven.war.plugin>
         <version.maven.javadoc.plugin>3.5.0</version.maven.javadoc.plugin>
@@ -65,6 +70,13 @@
                 <groupId>org.spockframework</groupId>
                 <artifactId>spock-bom</artifactId>
                 <version>2.4-M1-groovy-4.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>${version.jetty}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -93,29 +105,60 @@
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-core</artifactId>
-            <version>7.0.0-pr6</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.yahoo.elide</groupId>
-                    <artifactId>elide-graphql</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>${version.elide}</version>
         </dependency>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
-            <artifactId>elide-standalone</artifactId>
-            <version>7.0.0-pr6</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.yahoo.elide</groupId>
-                    <artifactId>elide-graphql</artifactId>
-                </exclusion>
-            </exclusions>
+            <artifactId>elide-datastore-jpa</artifactId>
+            <version>${version.elide}</version>
         </dependency>
+        <dependency>
+            <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-graphql</artifactId>
+            <version>${version.elide}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-test-helpers</artifactId>
+            <version>${version.elide}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>5.1.49</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>${version.validation.api}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <version>${version.jersey}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>3.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Hibernate -->
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>${hibernate.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-hikaricp</artifactId>
+            <version>${hibernate.version}</version>
         </dependency>
 
         <!-- Concurrency -->
@@ -154,6 +197,23 @@
             <groupId>org.objenesis</groupId>
             <artifactId>objenesis</artifactId>
             <version>3.0.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!--Jetty-->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/qubitpi/ws/jersey/template/application/BinderFactory.java
+++ b/src/main/java/com/qubitpi/ws/jersey/template/application/BinderFactory.java
@@ -15,8 +15,6 @@
  */
 package com.qubitpi.ws.jersey.template.application;
 
-import static com.yahoo.elide.standalone.Util.combineModelEntities;
-
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.ElideSettingsBuilder;
@@ -44,6 +42,7 @@ import org.hibernate.Session;
 import org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl;
 import org.hibernate.jpa.boot.internal.PersistenceUnitInfoDescriptor;
 
+import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.spi.PersistenceUnitInfo;
@@ -53,8 +52,10 @@ import net.jcip.annotations.ThreadSafe;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 /**
  * A binder factory builds a custom binder for the Jersey application.
@@ -167,7 +168,7 @@ public class BinderFactory {
 
                 final PersistenceUnitInfo persistenceUnitInfo = new PersistenceUnitInfoImpl(
                         "astraios",
-                        combineModelEntities(classScanner, modelPackageName, false),
+                        getAllEntities(classScanner, modelPackageName),
                         getDefaultDbConfigs(),
                         classLoader
                 );
@@ -177,6 +178,24 @@ public class BinderFactory {
                         new HashMap<>(),
                         classLoader
                 ).build();
+            }
+
+            /**
+             * Get all the entities in a package.
+             *
+             * @param scanner  An object that picks up entities by Elide annotation
+             * @param packageName  A fully qualified package name under which contains all entities
+             *
+             * @return all entities found in the provided package.
+             */
+            @NotNull
+            public static List<String> getAllEntities(
+                    @NotNull final ClassScanner scanner,
+                    @NotNull final String packageName
+            ) {
+                return scanner.getAnnotatedClasses(packageName, Entity.class).stream()
+                        .map(Class::getName)
+                        .collect(Collectors.toList());
             }
 
             /**

--- a/src/main/java/com/qubitpi/ws/jersey/template/application/ResourceConfig.java
+++ b/src/main/java/com/qubitpi/ws/jersey/template/application/ResourceConfig.java
@@ -38,7 +38,8 @@ import net.jcip.annotations.ThreadSafe;
 @ApplicationPath("/v1/data/")
 public class ResourceConfig extends org.glassfish.jersey.server.ResourceConfig {
 
-    private static final String ENDPOINT_PACKAGE = "com.yahoo.elide.jsonapi.resources";
+    private static final String GRAPHQL_ENDPOINT_PACKAGE = "com.yahoo.elide.graphql";
+    private static final String JAON_API_ENDPOINT_PACKAGE = "com.yahoo.elide.jsonapi.resources";
     private static final OAuthConfig OAUTH_CONFIG = ConfigFactory.create(OAuthConfig.class);
 
     /**
@@ -58,12 +59,12 @@ public class ResourceConfig extends org.glassfish.jersey.server.ResourceConfig {
      * @param binderFactory  An object that produces resource binder
      * @param oauthEnabled  Flag on whether or not to enable auth feature, mainly for differentiating dev/test and prod
      */
-    public ResourceConfig(
+    private ResourceConfig(
             @NotNull final ServiceLocator injector,
             @NotNull final BinderFactory binderFactory,
             final boolean oauthEnabled
     ) {
-        packages(ENDPOINT_PACKAGE);
+        packages(JAON_API_ENDPOINT_PACKAGE, GRAPHQL_ENDPOINT_PACKAGE);
 
         register(CorsFilter.class);
         if (oauthEnabled) {


### PR DESCRIPTION
Changelog
---------

### Added

- Enabled GraphQL endpoints:

  <img width="1792" alt="page" src="https://github.com/paion-data/astraios/assets/16126939/4a1eb8fa-9eaa-40ef-bcc2-664ef437a807">


### Changed

- **Changed documentation by removing `websocket` module from jetty install**

### Deprecated

### Removed

- Removed Elide-Standalone

### Fixed

### Security

Checklist
---------

- [x] Test
- [x] Self-review
- [x] Documentation

Reference
---------

- [JSR-356](https://jcp.org/en/jsr/detail?id=356)

  - [Subscription endpoint](https://github.com/yahoo/elide/blob/master/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/SubscriptionWebSocket.java#L55) _extends_ **Endpoint**:

    <img width="678" alt="page" src="https://github.com/paion-data/astraios/assets/16126939/67a5a4b7-9642-4543-8c85-eeebb38809dd">

- [Disabling GraphQL subscription](https://elide.io/pages/guide/v7/11.1-subscriptions.html#recommendations)
- [Elide GraphQL fetch query example](https://elide.io/pages/guide/v7/11-graphql.html#fetch-examples)
- [Elide GraphQL update query example](https://elide.io/pages/guide/v7/11-graphql.html#upsert-examples)
- [Removing websocket module from Jetty container](https://hub.docker.com/_/jetty#:~:text=Modules%20may%20be%20configured%20in,deactivated%20by%20removing%20that%20file.)