### PR TITLE
Enhance CORS filter

### DIFF
--- a/src/main/java/com/qubitpi/ws/jersey/template/web/filters/CorsFilter.java
+++ b/src/main/java/com/qubitpi/ws/jersey/template/web/filters/CorsFilter.java
@@ -17,28 +17,99 @@ package com.qubitpi.ws.jersey.template.web.filters;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.core.Response;
+import net.jcip.annotations.Immutable;
+import net.jcip.annotations.ThreadSafe;
 
 /**
- * {@link CorsFilter} prevents corss-origin request error in local dev environment.
+ * {@link CorsFilter} is a Jersey
+ * <a href="https://www.baeldung.com/jersey-filters-interceptors">pre-matching filter</a> handling CORS.
+ * <p>
+ * <ul>
+ *     <li> If the request is a preflight request, the webservice registered with {@link CorsFilter} will simply bounce
+ *          back the request with a 200 response with the following headers attached:
+ *          <ul>
+ *              <li> {@code "Access-Control-Allow-Headers": "CSRF-Token, X-Requested-By, Authorization, Content-Type"}
+ *              <li> {@code "Access-Control-Allow-Credentials": "true"}
+ *              <li> {@code "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS, HEAD, PATCH"}
+ *              <li> {@code "Access-Control-Allow-Origin": "*"}
+ *          </ul>
+ *     <li> If the request is not preflight but cross-origin the {@code "Access-Control-Allow-Origin": "*"} header will
+ *          be attached to the response
+ *     <li> If the request is neither preflight nor corss-origin, the response will be send back unmodified
+ * </ul>
+ * For more information, see this <a href="https://stackoverflow.com/a/28067653">post</a>
  */
-public class CorsFilter implements ContainerResponseFilter {
+@Immutable
+@ThreadSafe
+@PreMatching
+public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    @Override
+    public void filter(@NotNull final ContainerRequestContext request) {
+        if (isPreflightRequest(request)) {
+            request.abortWith(Response.ok().build());
+        }
+    }
 
     @Override
     public void filter(
             @NotNull final ContainerRequestContext request,
             @NotNull final ContainerResponseContext response
     ) {
+        if (!isCrossOriginRequest(request)) {
+            return;
+        }
+
+        if (isPreflightRequest(request)) {
+            response.getHeaders().add(
+                    "Access-Control-Allow-Headers",
+                    "CSRF-Token, X-Requested-By, Authorization, Content-Type"
+            );
+            response.getHeaders().add("Access-Control-Allow-Credentials", "true");
+            response.getHeaders().add(
+                    "Access-Control-Allow-Methods",
+                    "GET, POST, PUT, DELETE, OPTIONS, HEAD, PATCH"
+            );
+        }
+
         response.getHeaders().add("Access-Control-Allow-Origin", "*");
-        response.getHeaders().add(
-                "Access-Control-Allow-Headers",
-                "CSRF-Token, X-Requested-By, Authorization, Content-Type"
-        );
-        response.getHeaders().add("Access-Control-Allow-Credentials", "true");
-        response.getHeaders().add(
-                "Access-Control-Allow-Methods",
-                "GET, POST, PUT, DELETE, OPTIONS, HEAD, PATCH"
-        );
+    }
+
+    /**
+     * Returns whether or not a request is a cross-origin request.
+     * <p>
+     * A request is considered cross-origin if the request contains
+     * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin">"Origin"</a> header
+     *
+     * @param request  a pre-checked HTTP request, cannot be {@code null}
+     *
+     * @return {@code true} if the request is a cross-origin request or {@code false}, otherwise
+     */
+    private static boolean isCrossOriginRequest(@NotNull final ContainerRequestContext request) {
+        return request.getHeaderString("Origin") != null;
+    }
+
+    /**
+     * Returns whether or not a request is a preflight request.
+     * <p>
+     * A request is considered preflight if
+     * <ul>
+     *     <li> the request contains
+     *          <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin">"Origin"</a> header, and
+     *     <li> the request method is "OPTIONS"
+     * </ul>
+     *
+     * @param request  a pre-checked HTTP request, cannot be {@code null}
+     *
+     * @return {@code true} if the request is a preflight request or {@code false}, otherwise
+     */
+    private static boolean isPreflightRequest(@NotNull final ContainerRequestContext request) {
+        return isCrossOriginRequest(request)
+                && request.getMethod().equalsIgnoreCase("OPTIONS");
     }
 }


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

- Enhanced CORS filter by bouncing back corss-origin preflight requests

### Deprecated

### Removed

### Fixed

- Put CORS filter at the beginning of the request filtering chain so that corss-origin preflight request won't go through auth filter

### Security

Checklist
---------

- [x] Test
- [x] Self-review
- [x] Documentation

References
----------

- [A very good stackoverflow post on how to implement CORS filter](https://stackoverflow.com/a/28067653)
- [Jersey Filter `@Priorities`](https://eclipse-ee4j.github.io/jersey.github.io/documentation/latest/filters-and-interceptors.html#priorities)
- [@PreMatching](https://www.baeldung.com/jersey-filters-interceptors)
- [Merge maps in Groovy Spock](https://stackoverflow.com/a/13326983)