### PR TITLE
Align Dockerfile for test with production deployment logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,39 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM jetty:jdk17
+FROM ubuntu:22.04
 
 LABEL maintainer="Jiaqi (Jack) Liu"
 LABEL maintainer-email="jack20220723@gmail.com"
 
 ARG WS_VERSION=1.0-SNAPSHOT
 
-ENV JETTY_WEBAPPS_DIR /var/lib/jetty/webapps
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
 
-COPY ./target/jersey-ws-template-$WS_VERSION.war $JETTY_WEBAPPS_DIR/ROOT.war
+ENV JETTY_VERSION 11.0.15
+ENV JETTY_BASE /jetty-base
+ENV JETTY_HOME /jetty-home-$JETTY_VERSION
+ENV JETTY_WEBAPPS_DIR $JETTY_BASE/webapps
+
+RUN apt update
+RUN apt upgrade -y
+RUN apt install software-properties-common -y
+RUN apt install wget
+
+# Install JDK 17 - https://www.rosehosting.com/blog/how-to-install-java-17-lts-on-ubuntu-20-04/
+RUN apt update -y
+RUN apt install openjdk-17-jdk -y
+
+# Install and configure Jetty (for JDK 17) container
+RUN wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
+RUN tar -xzvf jetty-home-$JETTY_VERSION.tar.gz
+RUN rm jetty-home-$JETTY_VERSION.tar.gz
+RUN mkdir jetty-base
+RUN cd jetty-base && java -jar $JETTY_HOME/start.jar --add-module=annotations,server,http,deploy,servlet,webapp,resources,jsp
+
+COPY ./target/ersey-ws-template-$WS_VERSION.war $JETTY_WEBAPPS_DIR/ROOT.war
+
+ENV OAUTH_ENABLED false
+
+COPY ./Dockerfile-startup.sh /Dockerfile-startup.sh
+CMD [ "/Dockerfile-startup.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN rm jetty-home-$JETTY_VERSION.tar.gz
 RUN mkdir jetty-base
 RUN cd jetty-base && java -jar $JETTY_HOME/start.jar --add-module=annotations,server,http,deploy,servlet,webapp,resources,jsp
 
-COPY ./target/ersey-ws-template-$WS_VERSION.war $JETTY_WEBAPPS_DIR/ROOT.war
+COPY ./target/jersey-ws-template-$WS_VERSION.war $JETTY_WEBAPPS_DIR/ROOT.war
 
 ENV OAUTH_ENABLED false
 

--- a/Dockerfile-startup.sh
+++ b/Dockerfile-startup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -x
+set -e
+
+# Copyright Paion Data
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd $JETTY_BASE
+java -jar $JETTY_HOME/start.jar


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [ ] Test
- [ ] Self-review
- [ ] Documentation

Reference
---------

- https://github.com/paion-data/astraios/pull/33
- [Jetty is throwing `Unknown module' error when running with --add-to-start](https://stackoverflow.com/questions/69893759/jetty-is-throwing-unknown-module-error-when-running-with-add-to-start#:~:text=The%20fastest%20fix%20for%20you%20is%20to%20remove%20this%20bad%20Jetty%20package%20from%20your%20linux%20distribution%20and%20just%20download%20and%20use%20the%20official%20tarball.)
- [How to run multiple commands automatically at container startup](https://stackoverflow.com/a/68066710)

- [template_file](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file)

Lessons Learned
---------------

- Docker as a test & dev tool should match production deployment logics 
